### PR TITLE
added regex validation for emails in input fields

### DIFF
--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -56,8 +56,8 @@ features:
     - "Workflow name here"
     - "Another workflow namer here"
 
-    # Email regex to be used to restrict emails used during signing
-    email_regex: ^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$
+  # Email regex to be used to restrict emails used during signing
+  email_regex: ^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$
 
-    # Error to display if there is an error with the email validation
-    email_error_message: "There is a problem with your email address."
+  # Error to display if there is an error with the email validation
+  email_error_message: "There is a problem with your email address."

--- a/config/config.sample.yaml
+++ b/config/config.sample.yaml
@@ -9,7 +9,7 @@ port: 80
 # This is the server information needed to point the application to your Sign Console.
 server:
   # The host address to your Sign Console.
-  host: 
+  host:
 
   # DO NOT CHANGE THE FOLLOW TWO CONFIGURATION.
   # This is the endpoint
@@ -20,7 +20,7 @@ enterprise:
   # This is your integration key for Adobe Sign. This key
   # is needed to get access to perform synchronization between Admin
   # Console and Adobe Sign.
-  integration: 
+  integration:
 
 # This is the feature configuration.
 features:
@@ -55,3 +55,9 @@ features:
     #- Notice how list items are comment out
     - "Workflow name here"
     - "Another workflow namer here"
+
+    # Email regex to be used to restrict emails used during signing
+    email_regex: ^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$
+
+    # Error to display if there is an error with the email validation
+    email_error_message: "There is a problem with your email address."

--- a/server.js
+++ b/server.js
@@ -123,7 +123,7 @@ app.get('/api/getLibraryDocuments/:id', async function(req, res, next) {
 });
 
 // POST /workflows/{workflowId}/agreements
-app.post('/api/postAgreement/:id', async function(req, res, next){
+app.post('/api/postAgreement/:id', async function(req, res){
 
     function postAgreement() {
         /***
@@ -142,9 +142,39 @@ app.post('/api/postAgreement/:id', async function(req, res, next){
             body: JSON.stringify(req.body)})
     }
 
-    const api_response = await postAgreement();
-    const data = await api_response.json();
+    // console.log('request body', req.body);
+    // console.log('body in JSON', JSON.stringify(req.body));
 
+    console.log('first', req.body.documentCreationInfo.recipientsListInfo);
+  console.log('second', req.body.documentCreationInfo.recipientsListInfo[0].recipients);
+
+  console.log(req.body.documentCreationInfo.recipientsListInfo.length);
+
+  let o = 0;
+
+  console.log(req.body.documentCreationInfo.recipientsListInfo.length > o);
+
+  let okToSubmit = true;
+
+  for (let o = 0; req.body.documentCreationInfo.recipientsListInfo.length > o; o++) {
+    console.log(req.body.documentCreationInfo.recipientsListInfo[o].recipients);
+    for (let i = 0; req.body.documentCreationInfo.recipientsListInfo[o].recipients.length > i; i++) {
+      console.log('hey we at least made it this far brah!');
+      if (!req.body.documentCreationInfo.recipientsListInfo[o].recipients[i].email.match(/^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/)) {
+        console.log('found bad email');
+        okToSubmit = false;
+      }
+    }
+  }
+  let data;
+   if (okToSubmit) {
+     const api_response = await postAgreement();
+     data = await api_response.json();
+   } else {
+     data = {code: 'MISC_ERROR', message: 'One or more emails are not formatted properly'};
+   }
+
+   console.log('return data', data);
     res.json(data);
 });
 
@@ -180,6 +210,7 @@ app.post('/api/postTransient', upload.single('myfile'), async function (req, res
     fs.unlink(req.file.path, function (err) {
         if (err) return console.log(err);
     });
+
 
     res.json(data)
   })

--- a/static/js/DynamicForm.js
+++ b/static/js/DynamicForm.js
@@ -66,6 +66,8 @@ class DynamicForm {
     let hide_all_cc_trigger = this.setHideAllTrigger(hide_cc_settings, hide_cc_list);
     let hide_cc_predefined_trigger = this.setHidePredefinedTrigger(
       hide_all_cc_trigger, hide_cc_settings, this.data['displayName'], hide_cc_list);
+    let email_regex = this.getEmailRegex('email_regex');
+    let email_error_message = this.getEmailErrorMessage('email_error_message');
 
 
     // Build Form Body
@@ -82,11 +84,12 @@ class DynamicForm {
 
     // Get Recipient Information
     for (let counter = 0; counter < this.data['recipientsListInfo'].length; counter++) {
-
+      let emailError = await email_error_message;
+      let emailRegex = await email_regex;
       let recipient_group_data = this.data['recipientsListInfo'][counter];
 
       this.recipient_groups.push(new RecipientGroup(
-        this.recipeint_group_id, this.parent_div.children[1].children, recipient_group_data));
+        this.recipeint_group_id, this.parent_div.children[1].children, recipient_group_data, emailRegex, emailError));
       this.recipient_groups[counter].createRecipientDiv();
       this.recipient_groups[counter].createRecipientLabelField();
       this.recipient_groups[counter].createRecipientInputField(hide_all_trigger, hide_predefined_trigger);
@@ -182,7 +185,7 @@ class DynamicForm {
 
   }
 
-  
+
 
   async getSignNowSetting(name) {
     /***
@@ -192,6 +195,26 @@ class DynamicForm {
     let sign_now_predefined_setting = await this.features;
 
     return sign_now_predefined_setting[name];
+  }
+
+  async getEmailRegex(name) {
+
+    /***
+     * This function gets the email_regex setting from the config file
+     */
+
+    let email_regex_setting = await this.features;
+
+    return email_regex_setting[name];
+  }
+
+  async getEmailErrorMessage(name) {
+    /***
+     * This function gets the email_error_message setting from the config file
+     */
+    let email_error_message_setting = await this.features;
+
+    return email_error_message_setting[name];
   }
 
   async getHidePredefinedSetting(name) {
@@ -493,7 +516,7 @@ class DynamicForm {
          async_wf_obj.clearData();
           alert(URlresponse['message']);
        }
-       
+
 
       }else{
         document.getElementById('loader').hidden = true;

--- a/static/js/RecipientGroup.js
+++ b/static/js/RecipientGroup.js
@@ -12,8 +12,10 @@ governing permissions and limitations under the License.
 
 class RecipientGroup{
 
-    constructor(group_id, parent_div, recipient_group_data){
+    constructor(group_id, parent_div, recipient_group_data, email_regex, email_error_message){
         this.parent_div = parent_div;
+        this.email_regex = email_regex;
+        this.email_error_message = email_error_message;
         this.group_id = group_id;
         this.recipient_group_data = recipient_group_data;
         this.number_of_members = 0;
@@ -28,11 +30,11 @@ class RecipientGroup{
 
         // Create the element
         var recipient_div = document.createElement('div');
-        
+
         // Add attributes
         recipient_div.id = "recipient_group_" + this.group_id;
         recipient_div.className = "add_border_bottom";
-        
+
         var parent_div = document.getElementById('recipient_section')
         parent_div.append(recipient_div);
 
@@ -73,6 +75,8 @@ class RecipientGroup{
         input.name = 'recipient_' + this.group_id;
         input.className = 'recipient_form_input';
         input.placeholder = "Enter Recipient's Email";
+        input.pattern = this.email_regex;
+        input.title = this.email_error_message;
 
         input.onchange = function(){
             this.email = input.value
@@ -161,6 +165,8 @@ class RecipientGroup{
         participent_input.placeholder = "Enter Recipient's Email";
         participent_input.id = participent_id;
         participent_input.name = participent_id;
+        participent_input.pattern = this.email_regex;
+        participent_input.title = this.email_error_message;
 
         // Append to the div before buttons
         var target = document.getElementById("add_section_" + this.group_id);


### PR DESCRIPTION

## Description

Two new fields in yaml config file with defaults. Provides basic email validation as without it the data sends to Sign and returns a very vague, unhelpful error. User can adjust the regex to restrict to certain domains, and can adjust message to show when email is not right. Does not include the front end portion. 

## Related Issue
#14 

## Motivation and Context

adds basic email validation and allows for user to restrict form to certain email domains

## How Has This Been Tested?

heavy local testing

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ x] My code follows the code style of this project.
- [ x] My change requires a change to the documentation.
- [ x] I have updated the documentation accordingly.
- [ x] I have read the **CONTRIBUTING** document.
- [ x] I have added tests to cover my changes.
- [x ] All new and existing tests passed.
